### PR TITLE
Counting non-distinct source values and adding note in t…

### DIFF
--- a/R/GenerateResultsDocument.R
+++ b/R/GenerateResultsDocument.R
@@ -55,10 +55,10 @@ generateResultsDocument<- function(results, outputFolder, authors, silent=FALSE)
   logo <- system.file("templates", "img", "darwin-logo.jpg", package="CdmOnboarding")
 
   # open a new doc from the doctemplate
-  doc<-officer::read_docx(path = docTemplate)
+  doc <- officer::read_docx(path = docTemplate)
 
   # add Title Page
-  doc<- doc %>%
+  doc <- doc %>%
     officer::body_add_img(logo, width = 5.00, height = 2.39, style = pkg.env$styles$title) %>%
     officer::body_add_par(sprintf("CDM Onboarding report for the %s database", results$databaseName), style = pkg.env$styles$title) %>%
     officer::body_add_par(paste(authors, collapse = ","), style = pkg.env$styles$subTitle) %>%
@@ -203,7 +203,7 @@ generateResultsDocument<- function(results, outputFolder, authors, silent=FALSE)
       )
     doc <- doc %>%
       officer::body_add_par("Mapping Completeness", style = pkg.env$styles$heading2) %>%
-      my_caption("Shows the percentage of codes that are mapped to the standardized vocabularies as well as the percentage of records. Note that there are no OMOP observation source codes.", sourceSymbol = pkg.env$sources$cdm, style = pkg.env$styles$tableCaption) %>%
+      my_caption("Shows the percentage of codes that are mapped to the standardized vocabularies as well as the percentage of records. Note: 1) for one-to-many mappings, the source codes will be counted multiple times so the reported total source codes could be bigger than actual number of unique source codes and 2) there are no OMOP observation source codes.", sourceSymbol = pkg.env$sources$cdm, style = pkg.env$styles$tableCaption) %>%
       my_body_add_table_runtime(vocabResults$mappingCompleteness, alignment = c('l', rep('r',6)))
 
     # Drug Level Mappings

--- a/inst/sql/sql_server/checks/mapping_completeness.sql
+++ b/inst/sql/sql_server/checks/mapping_completeness.sql
@@ -1,97 +1,97 @@
 select  'Condition' as domain,
-        count_big(distinct source_value) as n_codes_source,
+        count_big(source_value) as n_codes_source,
         sum(is_mapped) as n_codes_mapped,
-        100.0*sum(is_mapped) / count_big(distinct source_value) as p_codes_mapped,
+        100.0*sum(is_mapped) / count_big(source_value) as p_codes_mapped,
         sum(num_records) as n_records_source,
         sum(is_mapped * num_records) as n_records_mapped,
         100.0*sum(is_mapped * num_records)/sum(num_records) as p_records_mapped
 from #condition
 union all
 select  'Procedure',
-        count_big(distinct source_value),
+        count_big(source_value),
         sum(is_mapped),
-        100.0*sum(is_mapped) / count_big(distinct source_value),
+        100.0*sum(is_mapped) / count_big(source_value),
         sum(num_records),
         sum(is_mapped * num_records),
         100.0*sum(is_mapped * num_records)/sum(num_records)
 from #procedure
 union all
 select  'Drug',
-        count_big(distinct source_value),
+        count_big(source_value),
         sum(is_mapped),
-        100.0*sum(is_mapped) / count_big(distinct source_value),
+        100.0*sum(is_mapped) / count_big(source_value),
         sum(num_records),
         sum(is_mapped * num_records),
         100.0*sum(is_mapped * num_records)/sum(num_records)
 from #drug
 union all
 select  'Device',
-        count_big(distinct source_value),
+        count_big(source_value),
         sum(is_mapped),
-        100.0*sum(is_mapped) / count_big(distinct source_value),
+        100.0*sum(is_mapped) / count_big(source_value),
         sum(num_records),
         sum(is_mapped * num_records),
         100.0*sum(is_mapped * num_records)/sum(num_records)
 from #device
 union all
 select  'Observation',
-        count_big(distinct source_value),
+        count_big(source_value),
         sum(is_mapped),
-        100.0*sum(is_mapped) / count_big(distinct source_value),
+        100.0*sum(is_mapped) / count_big(source_value),
         sum(num_records),
         sum(is_mapped * num_records),
         100.0*sum(is_mapped * num_records)/sum(num_records)
 from #observation
 union all
 select  'Measurement',
-        count_big(distinct source_value),
+        count_big(source_value),
         sum(is_mapped),
-        100.0*sum(is_mapped) / count_big(distinct source_value),
+        100.0*sum(is_mapped) / count_big(source_value),
         sum(num_records),
         sum(is_mapped * num_records),
         100.0*sum(is_mapped * num_records)/sum(num_records)
 from #measurement
 union all
 select  'Specimen',
-        count_big(distinct source_value),
+        count_big(source_value),
         sum(is_mapped),
-        100.0*sum(is_mapped) / count_big(distinct source_value),
+        100.0*sum(is_mapped) / count_big(source_value),
         sum(num_records),
         sum(is_mapped * num_records),
         100.0*sum(is_mapped * num_records)/sum(num_records)
 from #specimen
 union all
 select  'Visit',
-        count_big(distinct source_value),
+        count_big(source_value),
         sum(is_mapped),
-        100.0*sum(is_mapped) / count_big(distinct source_value),
+        100.0*sum(is_mapped) / count_big(source_value),
         sum(num_records),
         sum(is_mapped * num_records),
         100.0*sum(is_mapped * num_records)/sum(num_records)
 from #visit
 union all
 select  'Measurement Unit',
-        count_big(distinct source_value),
+        count_big(source_value),
         sum(is_mapped),
-        100.0*sum(is_mapped) / count_big(distinct source_value),
+        100.0*sum(is_mapped) / count_big(source_value),
         sum(num_records),
         sum(is_mapped * num_records),
         100.0*sum(is_mapped * num_records)/sum(num_records)
 from #meas_unit
 union all
 select  'Observation Unit',
-        count_big(distinct source_value),
+        count_big(source_value),
         sum(is_mapped),
-        100.0*sum(is_mapped) / count_big(distinct source_value),
+        100.0*sum(is_mapped) / count_big(source_value),
         sum(num_records),
         sum(is_mapped * num_records),
         100.0*sum(is_mapped * num_records)/sum(num_records)
 from #obs_unit
 union all
 select  'Measurement value',
-        count_big(distinct source_value),
+        count_big(source_value),
         sum(is_mapped),
-        100.0*sum(is_mapped) / count_big(distinct source_value),
+        100.0*sum(is_mapped) / count_big(source_value),
         sum(num_records),
         sum(is_mapped * num_records),
         100.0*sum(is_mapped * num_records)/sum(num_records)
@@ -107,36 +107,36 @@ select  'Observation value',
 from #obs_value
 union all
 select  'Provider Specialty' ,
-        count_big(distinct source_value),
+        count_big(source_value),
         sum(is_mapped),
-        100.0*sum(is_mapped) / count_big(distinct source_value),
+        100.0*sum(is_mapped) / count_big(source_value),
         sum(num_records),
         sum(is_mapped * num_records),
         100.0*sum(is_mapped * num_records)/sum(num_records)
 from #specialty
 union all
 select  'Condition status',
-        count_big(distinct source_value),
+        count_big(source_value),
         sum(is_mapped),
-        100.0*sum(is_mapped) / count_big(distinct source_value),
+        100.0*sum(is_mapped) / count_big(source_value),
         sum(num_records),
         sum(is_mapped * num_records),
         100.0*sum(is_mapped * num_records)/sum(num_records)
 from #cond_status
 union all
 select  'Death cause' ,
-        count_big(distinct source_value),
+        count_big(source_value),
         sum(is_mapped),
-        100.0*sum(is_mapped) / count_big(distinct source_value),
+        100.0*sum(is_mapped) / count_big(source_value),
         sum(num_records),
         sum(is_mapped * num_records),
         100.0*sum(is_mapped * num_records)/sum(num_records)
 from #death_cause
 union all
 select  'Drug Route' ,
-        count_big(distinct source_value),
+        count_big(source_value),
         sum(is_mapped),
-        100.0*sum(is_mapped) / count_big(distinct source_value),
+        100.0*sum(is_mapped) / count_big(source_value),
         sum(num_records),
         sum(is_mapped * num_records),
         100.0*sum(is_mapped * num_records)/sum(num_records)


### PR DESCRIPTION
Fixes #63. Removing distinct source_value count and adding a note that the total source code count might be bigger than actual number of unique source codes (due to one-to-many mappings).

A more optimal solution would be to only count distinct source codes that are mapped, requiring a nested sql:
```sql
select 
    'Condition' as domain,
    n_codes_source,
    n_codes_mapped,
    100.0 * n_codes_mapped / n_codes_source as p_codes_mapped,
    n_records_source,
    n_records_mapped,
    100.0 * n_records_mapped / n_records_source as p_records_mapped
from (
    select
        count(distinct source_value) as n_codes_source,            
        sum(num_records) as n_records_source,
        sum(is_mapped * num_records) as n_records_mapped,
    from condition
) Z
cross join (
    select sum(is_mapped) as n_codes_mapped 
    from (
        select distinct source_value, is_mapped
        from condition
    ) A
) B
;
```